### PR TITLE
Add breakpoint functionality and run controls

### DIFF
--- a/src/components/ScriptDisplay.tsx
+++ b/src/components/ScriptDisplay.tsx
@@ -1,18 +1,23 @@
 
 import React, { useEffect, useRef } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Circle } from "lucide-react";
 import { ScriptInstruction } from "@/utils/scriptUtils";
 
 interface ScriptDisplayProps {
   instructions: ScriptInstruction[];
   currentIndex: number;
   unlockingScriptLength: number;
+  breakpoints: number[];
+  onToggleBreakpoint: (index: number) => void;
 }
 
-const ScriptDisplay: React.FC<ScriptDisplayProps> = ({ 
-  instructions, 
-  currentIndex, 
-  unlockingScriptLength 
+const ScriptDisplay: React.FC<ScriptDisplayProps> = ({
+  instructions,
+  currentIndex,
+  unlockingScriptLength,
+  breakpoints,
+  onToggleBreakpoint
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const currentInstructionRef = useRef<HTMLDivElement>(null);
@@ -40,6 +45,7 @@ const ScriptDisplay: React.FC<ScriptDisplayProps> = ({
             const isUnlockingScript = index < unlockingScriptLength;
             const isCurrent = index === currentIndex;
             const isExecuted = index < currentIndex;
+            const hasBreakpoint = breakpoints.includes(index);
             
             return (
               <div
@@ -73,8 +79,19 @@ const ScriptDisplay: React.FC<ScriptDisplayProps> = ({
                       </span>
                     )}
                   </span>
-                  <span className="text-xs text-slate-500">
-                    {index + 1}/{instructions.length}
+                  <span className="flex items-center gap-2">
+                    <button
+                      onClick={() => onToggleBreakpoint(index)}
+                      className="p-0 m-0"
+                    >
+                      <Circle
+                        size={12}
+                        className={hasBreakpoint ? 'text-red-500 fill-red-500' : 'text-slate-500'}
+                      />
+                    </button>
+                    <span className="text-xs text-slate-500">
+                      {index + 1}/{instructions.length}
+                    </span>
                   </span>
                 </div>
               </div>

--- a/src/components/ScriptInterpreter.tsx
+++ b/src/components/ScriptInterpreter.tsx
@@ -122,21 +122,6 @@ const ScriptInterpreter = () => {
     });
   }, [scriptState, toast]);
 
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'F10') {
-        event.preventDefault();
-        executeNextStep();
-      }
-      if (event.key === 'F5') {
-        event.preventDefault();
-        continueExecution();
-      }
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [executeNextStep, continueExecution]);
-
   const executeNextStep = useCallback(() => {
     if (!scriptState || scriptState.isComplete) return;
     
@@ -163,6 +148,21 @@ const ScriptInterpreter = () => {
       setIsExecuting(false);
     }
   }, [scriptState, toast]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'F10') {
+        event.preventDefault();
+        executeNextStep();
+      }
+      if (event.key === 'F5') {
+        event.preventDefault();
+        continueExecution();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [executeNextStep, continueExecution]);
 
   const resetExecution = useCallback(() => {
     setScriptState(null);

--- a/src/components/ScriptInterpreter.tsx
+++ b/src/components/ScriptInterpreter.tsx
@@ -16,6 +16,7 @@ const ScriptInterpreter = () => {
   const [lockingScript, setLockingScript] = useState("");
   const [scriptState, setScriptState] = useState<ScriptState | null>(null);
   const [isExecuting, setIsExecuting] = useState(false);
+  const [breakpoints, setBreakpoints] = useState<number[]>([]);
   const { toast } = useToast();
 
   // Load scripts from URL parameters on component mount
@@ -29,15 +30,18 @@ const ScriptInterpreter = () => {
         setLockingScript(urlParams.lock);
       }
     }
+    if (urlParams.breakpoints) {
+      setBreakpoints(urlParams.breakpoints);
+    }
   }, [toast]);
 
   // Update URL when scripts change (debounced)
   useEffect(() => {
     const timeoutId = setTimeout(() => {
-      updateUrlWithScripts(unlockingScript, lockingScript);
+      updateUrlWithScripts(unlockingScript, lockingScript, breakpoints);
     }, 1000);
     return () => clearTimeout(timeoutId);
-  }, [unlockingScript, lockingScript]);
+  }, [unlockingScript, lockingScript, breakpoints]);
 
   const initializeExecution = useCallback(() => {
     try {
@@ -73,6 +77,66 @@ const ScriptInterpreter = () => {
     }
   }, [unlockingScript, lockingScript, toast]);
 
+  const toggleBreakpoint = useCallback((index: number) => {
+    setBreakpoints((prev) =>
+      prev.includes(index)
+        ? prev.filter((bp) => bp !== index)
+        : [...prev, index].sort((a, b) => a - b)
+    );
+  }, []);
+
+  const continueExecution = useCallback(() => {
+    if (!scriptState || scriptState.isComplete) return;
+    let state = scriptState;
+    do {
+      state = executeStep(state);
+    } while (!state.isComplete && !breakpoints.includes(state.currentIndex));
+    setScriptState(state);
+
+    if (state.isComplete) {
+      setIsExecuting(false);
+      toast({
+        title: state.isValid ? 'Script Valid!' : 'Script Invalid',
+        description: state.isValid
+          ? 'Script executed successfully'
+          : 'Script execution failed',
+        variant: state.isValid ? 'default' : 'destructive',
+      });
+    }
+  }, [scriptState, breakpoints, toast]);
+
+  const runToEnd = useCallback(() => {
+    if (!scriptState || scriptState.isComplete) return;
+    let state = scriptState;
+    while (!state.isComplete) {
+      state = executeStep(state);
+    }
+    setScriptState(state);
+    setIsExecuting(false);
+    toast({
+      title: state.isValid ? 'Script Valid!' : 'Script Invalid',
+      description: state.isValid
+        ? 'Script executed successfully'
+        : 'Script execution failed',
+      variant: state.isValid ? 'default' : 'destructive',
+    });
+  }, [scriptState, toast]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'F10') {
+        event.preventDefault();
+        executeNextStep();
+      }
+      if (event.key === 'F5') {
+        event.preventDefault();
+        continueExecution();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [executeNextStep, continueExecution]);
+
   const executeNextStep = useCallback(() => {
     if (!scriptState || scriptState.isComplete) return;
     
@@ -106,7 +170,11 @@ const ScriptInterpreter = () => {
   }, []);
 
   const shareScript = useCallback(async () => {
-    const shareableUrl = generateShareableUrl(unlockingScript, lockingScript);
+    const shareableUrl = generateShareableUrl(
+      unlockingScript,
+      lockingScript,
+      breakpoints
+    );
     
     try {
       await navigator.clipboard.writeText(shareableUrl);
@@ -128,7 +196,7 @@ const ScriptInterpreter = () => {
         description: "Shareable link has been copied to your clipboard",
       });
     }
-  }, [unlockingScript, lockingScript, toast]);
+  }, [unlockingScript, lockingScript, breakpoints, toast]);
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -172,13 +240,29 @@ const ScriptInterpreter = () => {
           >
             Initialize Execution
           </Button>
-          <Button 
-            onClick={executeNextStep} 
+          <Button
+            onClick={executeNextStep}
             disabled={!scriptState || scriptState.isComplete}
             variant="outline"
             className="border-blue-400 text-blue-400 hover:bg-blue-400 hover:text-slate-900"
           >
             Next Step
+          </Button>
+          <Button
+            onClick={continueExecution}
+            disabled={!scriptState || scriptState.isComplete}
+            variant="outline"
+            className="border-blue-400 text-blue-400 hover:bg-blue-400 hover:text-slate-900"
+          >
+            Continue
+          </Button>
+          <Button
+            onClick={runToEnd}
+            disabled={!scriptState || scriptState.isComplete}
+            variant="outline"
+            className="border-blue-400 text-blue-400 hover:bg-blue-400 hover:text-slate-900"
+          >
+            Run To End
           </Button>
           <Button 
             onClick={resetExecution} 
@@ -203,10 +287,12 @@ const ScriptInterpreter = () => {
       <div className="space-y-6">
         {scriptState && (
           <>
-            <ScriptDisplay 
+            <ScriptDisplay
               instructions={scriptState.instructions}
               currentIndex={scriptState.currentIndex}
               unlockingScriptLength={scriptState.unlockingScriptLength}
+              breakpoints={breakpoints}
+              onToggleBreakpoint={toggleBreakpoint}
             />
             <Separator className="bg-slate-600" />
             <StackVisualizer 

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/utils/urlUtils.ts
+++ b/src/utils/urlUtils.ts
@@ -5,6 +5,7 @@
 export interface ScriptParams {
   unlock?: string;
   lock?: string;
+  breakpoints?: number[];
 }
 
 /**
@@ -40,6 +41,7 @@ export const parseScriptParamsFromUrl = (): ScriptParams => {
   
   const unlockParam = urlParams.get('unlock');
   const lockParam = urlParams.get('lock');
+  const bpParam = urlParams.get('bp');
   
   if (unlockParam) {
     params.unlock = decodeScriptFromUrl(unlockParam);
@@ -48,6 +50,13 @@ export const parseScriptParamsFromUrl = (): ScriptParams => {
   if (lockParam) {
     params.lock = decodeScriptFromUrl(lockParam);
   }
+
+  if (bpParam) {
+    params.breakpoints = bpParam
+      .split(',')
+      .map((n) => parseInt(n, 10))
+      .filter((n) => !isNaN(n));
+  }
   
   return params;
 };
@@ -55,7 +64,11 @@ export const parseScriptParamsFromUrl = (): ScriptParams => {
 /**
  * Generates a shareable URL with encoded scripts
  */
-export const generateShareableUrl = (unlockingScript: string, lockingScript: string): string => {
+export const generateShareableUrl = (
+  unlockingScript: string,
+  lockingScript: string,
+  breakpoints: number[] = []
+): string => {
   const baseUrl = window.location.origin + window.location.pathname;
   const params = new URLSearchParams();
   
@@ -67,13 +80,21 @@ export const generateShareableUrl = (unlockingScript: string, lockingScript: str
     params.set('lock', encodeScriptForUrl(lockingScript));
   }
   
+  if (breakpoints.length > 0) {
+    params.set('bp', breakpoints.join(','));
+  }
+
   return params.toString() ? `${baseUrl}?${params.toString()}` : baseUrl;
 };
 
 /**
  * Updates the current URL with script parameters without page reload
  */
-export const updateUrlWithScripts = (unlockingScript: string, lockingScript: string): void => {
+export const updateUrlWithScripts = (
+  unlockingScript: string,
+  lockingScript: string,
+  breakpoints: number[] = []
+): void => {
   const params = new URLSearchParams();
   
   if (unlockingScript.trim()) {
@@ -84,7 +105,11 @@ export const updateUrlWithScripts = (unlockingScript: string, lockingScript: str
     params.set('lock', encodeScriptForUrl(lockingScript));
   }
   
-  const newUrl = params.toString() 
+  if (breakpoints.length > 0) {
+    params.set('bp', breakpoints.join(','));
+  }
+
+  const newUrl = params.toString()
     ? `${window.location.pathname}?${params.toString()}`
     : window.location.pathname;
     

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 import type { Config } from "tailwindcss";
 import colors from "tailwindcss/colors";
+import animatePlugin from "tailwindcss-animate";
 
 // Remove deprecated colors to avoid warnings
 const { lightBlue, warmGray, trueGray, coolGray, blueGray, ...tailwindColors } = colors;
@@ -110,5 +111,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- enable breakpoint handling in ScriptDisplay
- add execution control helpers in ScriptInterpreter with hotkeys
- store breakpoint indexes in the URL
- fix lint issues in helper components and tailwind config

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6881646db380832ea2f841f132a65a40